### PR TITLE
Removed unnecessary microsecond factor from livetime formula

### DIFF
--- a/stixdcpy/science.py
+++ b/stixdcpy/science.py
@@ -317,7 +317,7 @@ class ScienceL1(ScienceData):
                 trig_idx = inst.detector_id_to_trigger_index(det)
                 nin = photons_in[:, trig_idx]
                 live_ratio[:, det] = np.exp(
-                    -BETA * nin * ASIC_TAU * 1e-6) / (1 + nin * TRIG_TAU)
+                    -BETA * nin * ASIC_TAU) / (1 + nin * TRIG_TAU)
             corrected_rate = count_rate / live_ratio[:, :, None, None]
             return {
                 'corrected_rates': corrected_rate,


### PR DESCRIPTION
Removed the factor of 1e-6 in the formula for live ratio since ASIC_TAU is given in microseconds, so we don't need this factor. 